### PR TITLE
[SOLUTION] Spring-boot banner

### DIFF
--- a/spring-boot_banner/src/test/resources/application.properties
+++ b/spring-boot_banner/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.banner-mode=OFF

--- a/spring-boot_banner/src/test/resources/application.properties
+++ b/spring-boot_banner/src/test/resources/application.properties
@@ -1,1 +1,15 @@
+# Copyright 2023 Robert Scholte
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 spring.main.banner-mode=OFF


### PR DESCRIPTION
When executing a `@SpringBootTest`, the complete application will be started. This includes the display of the banner.
To suppress it, you can't use the logging framework yet, as it hasn't been initialized yet.
Instead you need to use the property `spring.main.banner-mode` and set it to `OFF`

