### PR TITLE
[SOLUTION] Spring-boot jpa

### DIFF
--- a/spring-boot_jpa/src/test/java/com/sourcegrounds/lesslogging/repository/LoremRepositoryTest.java
+++ b/spring-boot_jpa/src/test/java/com/sourcegrounds/lesslogging/repository/LoremRepositoryTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
+@DataJpaTest( showSql = false )
 class LoremRepositoryTest
 {
     @Autowired


### PR DESCRIPTION
If you compare the output of the standard logging with the jpa logging you should notice some differences: no loglevel, no date. That's a sign something that jpa is using a different logging mechanism. 

Weird enough, I would expect `spring.jpa.show-sql=false` to work, but it didn't. I would prefer the usage of the property, so you don't have to adjust every DataJpaTest, but can control it with a single property.