### PR TITLE
[SOLUTION] Logging JUL

### DIFF
--- a/logging_jul/pom.xml
+++ b/logging_jul/pom.xml
@@ -25,6 +25,20 @@ limitations under the License.
 	</parent>
 	<artifactId>logging_jul</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<java.util.logging.config.file>src/test/resources/logging-test.properties</java.util.logging.config.file>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<dependencies>
 		<dependency>

--- a/logging_jul/src/test/resources/logging-test.properties
+++ b/logging_jul/src/test/resources/logging-test.properties
@@ -1,0 +1,14 @@
+# Copyright 2023 Robert Scholte
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+.level=OFF


### PR DESCRIPTION
Add logging-test.properties and configure maven-surefire-plugin to suppress logging during test

Be aware that `java.util.logging.config.file` refers to a File, not to a classpath resource.
Most people expect this file to be under `src/main/resources`, which results that this file is accessible on the classpath, but that's not how JUL will access the configuration file.